### PR TITLE
Handle repeated identical features gracefully.

### DIFF
--- a/common/src/main/java/dev/corgitaco/featurerecycler/FeatureRecycler.java
+++ b/common/src/main/java/dev/corgitaco/featurerecycler/FeatureRecycler.java
@@ -33,7 +33,7 @@ public class FeatureRecycler {
     }
 
 
-    public static <T extends Holder<Biome>> List<FeatureSorter.StepFeatureData> recycle(List<T> biomes, Function<T, List<HolderSet<PlacedFeature>>> toFeatueSetFunction) {
+    public static <T extends Holder<Biome>> List<FeatureSorter.StepFeatureData> recycle(List<T> biomes, Function<T, List<HolderSet<PlacedFeature>>> toFeatureSetFunction) {
         long startTime = System.currentTimeMillis();
         LOGGER.info("Starting feature recycler...");
 
@@ -47,7 +47,7 @@ public class FeatureRecycler {
         }
 
         for (T biome : biomes) {
-            List<HolderSet<PlacedFeature>> features = toFeatueSetFunction.apply(biome);
+            List<HolderSet<PlacedFeature>> features = toFeatureSetFunction.apply(biome).stream().distinct().toList();
 
             for (int i = 0; i < features.size(); i++) {
                 HolderSet<PlacedFeature> feature = features.get(i);


### PR DESCRIPTION
This change handles when `GenerationStep.Decoration.values()` is smaller than `toFeatureSetFunction.apply(biome)` because of repeated identical features in the latter, by deduplicating the feature list.  (If the list were actually a set, this wouldn't be necessary.)

I have a (large) mod set with which this issue is reproducible.  A build of Feature Recycler with this change does not crash and does fix the feature order cycles.

- Deduplicate features (resolves #3)