### PR TITLE
Replace Stream.distinct() from PR #5 with a restructured logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
-#2.0.0.1
-*Handle repeated identical features gracefully.
+# 2.0.2
+* Multithread feature recycling.
+
+# 2.0.1
+* Handle repeated identical features gracefully.

--- a/common/src/main/java/dev/corgitaco/featurerecycler/FeatureRecycler.java
+++ b/common/src/main/java/dev/corgitaco/featurerecycler/FeatureRecycler.java
@@ -3,9 +3,13 @@ package dev.corgitaco.featurerecycler;
 import com.mojang.logging.LogUtils;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectLinkedOpenHashMap;
+import net.minecraft.ReportType;
+import net.minecraft.ReportedException;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.util.Unit;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.FeatureSorter;
 import net.minecraft.world.level.levelgen.GenerationStep;
@@ -14,15 +18,22 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 public class FeatureRecycler {
 
-    /** The mod id for Feature Recycler */
+    /**
+     * The mod id for Feature Recycler
+     */
     public static final String MOD_ID = "featurerecycler";
 
-    /** The logger for Feature Recycler */
+    /**
+     * The logger for Feature Recycler
+     */
     public static final Logger LOGGER = LogUtils.getLogger();
 
     /**
@@ -32,12 +43,14 @@ public class FeatureRecycler {
 
     }
 
+    private static final ExecutorService FEATURE_RECYCLER_SERVICE = makeExecutor();
+
 
     public static <T extends Holder<Biome>> List<FeatureSorter.StepFeatureData> recycle(List<T> biomes, Function<T, List<HolderSet<PlacedFeature>>> toFeatureSetFunction) {
         long startTime = System.currentTimeMillis();
         LOGGER.info("Starting feature recycler...");
 
-        int crashesPrevented = 0;
+        AtomicInteger crashesPrevented = new AtomicInteger(0);
 
         List<Map<T, List<Holder<PlacedFeature>>>> biomeTracker = new ArrayList<>();
 
@@ -46,90 +59,100 @@ public class FeatureRecycler {
             biomeTracker.add(new Reference2ObjectLinkedOpenHashMap<>());
         }
 
+
         for (T biome : biomes) {
             List<HolderSet<PlacedFeature>> features = toFeatureSetFunction.apply(biome).stream().distinct().toList();
 
-            for (int i = 0; i < features.size(); i++) {
-                HolderSet<PlacedFeature> feature = features.get(i);
-                biomeTracker.get(i).put(biome, new ArrayList<>(feature.stream().toList()));
+            for (int featureStep = 0; featureStep < features.size(); featureStep++) {
+                HolderSet<PlacedFeature> feature = features.get(featureStep);
+                biomeTracker.get(featureStep).put(biome, new ArrayList<>(feature.stream().toList()));
             }
         }
 
 
-        for (Map<T, List<Holder<PlacedFeature>>> featuresForBiomeStage : biomeTracker) {
-            for (int biomeIdx = 0; biomeIdx < biomes.size(); biomeIdx++) {
-                T biome = biomes.get(biomeIdx);
-                List<Holder<PlacedFeature>> currentList = featuresForBiomeStage.get(biome);
-                if (currentList == null) {
-                    continue;
-                }
+        CompletableFuture<Unit>[] futures = new CompletableFuture[biomeTracker.size()];
 
-                for (int currentHolderIndex = 0; currentHolderIndex < currentList.size(); currentHolderIndex++) {
-                    Holder<PlacedFeature> currentHolder = currentList.get(currentHolderIndex);
+        for (int i = 0; i < biomeTracker.size(); i++) {
+            Map<T, List<Holder<PlacedFeature>>> featuresForBiomeStage = biomeTracker.get(i);
+            CompletableFuture<Unit> result = CompletableFuture.supplyAsync(() -> {
+                for (int biomeIdx = 0; biomeIdx < biomes.size(); biomeIdx++) {
+                    T biome = biomes.get(biomeIdx);
+                    List<Holder<PlacedFeature>> currentList = featuresForBiomeStage.get(biome);
+                    if (currentList == null) {
+                        continue;
+                    }
 
-                    for (int nextHolderIndex = currentHolderIndex + 1; nextHolderIndex < currentList.size(); nextHolderIndex++) {
-                        Holder<PlacedFeature> nextHolder = currentList.get(nextHolderIndex);
-                        int currentFeatureIDX = -1;
-                        int nextFeatureIDX = -1;
-                        Holder<Biome> biomeRuleSetter = null;
+                    for (int currentHolderIndex = 0; currentHolderIndex < currentList.size(); currentHolderIndex++) {
+                        Holder<PlacedFeature> currentHolder = currentList.get(currentHolderIndex);
 
-                        for (int previousBiomeIdx = 0; previousBiomeIdx < biomeIdx - 1; previousBiomeIdx++) {
-                            T previousBiome = biomes.get(previousBiomeIdx);
-                            List<Holder<PlacedFeature>> previousBiomeStageData = featuresForBiomeStage.get(previousBiome);
-                            if (previousBiomeStageData == null) {
-                                continue;
-                            }
+                        for (int nextHolderIndex = currentHolderIndex + 1; nextHolderIndex < currentList.size(); nextHolderIndex++) {
+                            Holder<PlacedFeature> nextHolder = currentList.get(nextHolderIndex);
+                            int currentFeatureIDX = -1;
+                            int nextFeatureIDX = -1;
+                            Holder<Biome> biomeRuleSetter = null;
 
-                            if (currentFeatureIDX >= 0 && nextFeatureIDX >= 0) {
-                                break;
-                            }
-
-                            int previousBiomeCurrentFeatureIDX = -1;
-                            int previousBiomeNextFeatureIDX = -1;
-                            for (int previousBiomeHolderIdx = 0; previousBiomeHolderIdx < previousBiomeStageData.size(); previousBiomeHolderIdx++) {
-                                Holder<PlacedFeature> previousBiomePlacedFeatureHolder = previousBiomeStageData.get(previousBiomeHolderIdx);
-
-                                if (previousBiomePlacedFeatureHolder == currentHolder) {
-                                    previousBiomeCurrentFeatureIDX = previousBiomeHolderIdx;
+                            for (int previousBiomeIdx = 0; previousBiomeIdx < biomeIdx - 1; previousBiomeIdx++) {
+                                T previousBiome = biomes.get(previousBiomeIdx);
+                                List<Holder<PlacedFeature>> previousBiomeStageData = featuresForBiomeStage.get(previousBiome);
+                                if (previousBiomeStageData == null) {
+                                    continue;
                                 }
 
-                                if (previousBiomePlacedFeatureHolder == nextHolder) {
-                                    previousBiomeNextFeatureIDX = previousBiomeHolderIdx;
-                                }
-
-
-                                if (previousBiomeCurrentFeatureIDX >= 0 && previousBiomeNextFeatureIDX >= 0) {
+                                if (currentFeatureIDX >= 0 && nextFeatureIDX >= 0) {
                                     break;
                                 }
+
+                                int previousBiomeCurrentFeatureIDX = -1;
+                                int previousBiomeNextFeatureIDX = -1;
+                                for (int previousBiomeHolderIdx = 0; previousBiomeHolderIdx < previousBiomeStageData.size(); previousBiomeHolderIdx++) {
+                                    Holder<PlacedFeature> previousBiomePlacedFeatureHolder = previousBiomeStageData.get(previousBiomeHolderIdx);
+
+                                    if (previousBiomePlacedFeatureHolder == currentHolder) {
+                                        previousBiomeCurrentFeatureIDX = previousBiomeHolderIdx;
+                                    }
+
+                                    if (previousBiomePlacedFeatureHolder == nextHolder) {
+                                        previousBiomeNextFeatureIDX = previousBiomeHolderIdx;
+                                    }
+
+
+                                    if (previousBiomeCurrentFeatureIDX >= 0 && previousBiomeNextFeatureIDX >= 0) {
+                                        break;
+                                    }
+                                }
+
+                                currentFeatureIDX = previousBiomeCurrentFeatureIDX;
+                                nextFeatureIDX = previousBiomeNextFeatureIDX;
+                                biomeRuleSetter = previousBiome;
                             }
+                            if (currentFeatureIDX >= 0 && nextFeatureIDX >= 0) {
+                                if (currentFeatureIDX > nextFeatureIDX) {
+                                    ResourceLocation currentBiomeLocation = biome.unwrapKey().isEmpty() ? null : biome.unwrapKey().orElseThrow().location();
+                                    String currentBiomeName = currentBiomeLocation == null ? "???" : currentBiomeLocation.toString();
+                                    String currentFeatureName = currentHolder.unwrapKey().isEmpty() ? "???" : currentHolder.unwrapKey().orElseThrow().location().toString();
+                                    String nextFeatureName = nextHolder.unwrapKey().isEmpty() ? "???" : nextHolder.unwrapKey().orElseThrow().location().toString();
+                                    ResourceLocation ruleSetterLocation = biomeRuleSetter.unwrapKey().isEmpty() ? null : biomeRuleSetter.unwrapKey().orElseThrow().location();
+                                    String biomeRuleSetterName = ruleSetterLocation == null ? "???" : ruleSetterLocation.toString();
 
-                            currentFeatureIDX = previousBiomeCurrentFeatureIDX;
-                            nextFeatureIDX = previousBiomeNextFeatureIDX;
-                            biomeRuleSetter = previousBiome;
-                        }
-                        if (currentFeatureIDX >= 0 && nextFeatureIDX >= 0) {
-                            if (currentFeatureIDX > nextFeatureIDX) {
-                                ResourceLocation currentBiomeLocation = biome.unwrapKey().isEmpty() ? null : biome.unwrapKey().orElseThrow().location();
-                                String currentBiomeName = currentBiomeLocation == null ? "???" : currentBiomeLocation.toString();
-                                String currentFeatureName = currentHolder.unwrapKey().isEmpty() ? "???" : currentHolder.unwrapKey().orElseThrow().location().toString();
-                                String nextFeatureName = nextHolder.unwrapKey().isEmpty() ? "???" : nextHolder.unwrapKey().orElseThrow().location().toString();
-                                ResourceLocation ruleSetterLocation = biomeRuleSetter.unwrapKey().isEmpty() ? null : biomeRuleSetter.unwrapKey().orElseThrow().location();
-                                String biomeRuleSetterName = ruleSetterLocation == null ? "???" :  ruleSetterLocation.toString();
-
-                                LOGGER.warn("Moved placed feature \"%s\" from index %d to index %d for biome \"%s\". Placed Feature index rules set by biome \"%s\".".formatted(currentFeatureName, currentHolderIndex, nextHolderIndex, currentBiomeName, biomeRuleSetterName));
-                                LOGGER.warn("Moved placed feature \"%s\" from index %d to index %d for biome \"%s\". Placed Feature index rules set by biome \"%s\".".formatted(nextFeatureName, nextHolderIndex, currentHolderIndex, currentBiomeName, biomeRuleSetterName));
+                                    LOGGER.warn("Moved placed feature \"%s\" from index %d to index %d for biome \"%s\". Placed Feature index rules set by biome \"%s\".".formatted(currentFeatureName, currentHolderIndex, nextHolderIndex, currentBiomeName, biomeRuleSetterName));
+                                    LOGGER.warn("Moved placed feature \"%s\" from index %d to index %d for biome \"%s\". Placed Feature index rules set by biome \"%s\".".formatted(nextFeatureName, nextHolderIndex, currentHolderIndex, currentBiomeName, biomeRuleSetterName));
 
 
-                                LOGGER.warn("Just prevented a crash between %s and %s! Please report the issues to their respective issue trackers.".formatted(currentBiomeLocation == null ? "???" : currentBiomeLocation.getNamespace(), ruleSetterLocation == null ? "???" : ruleSetterLocation.getNamespace()));
-                                crashesPrevented++;
-                                currentList.set(currentHolderIndex, nextHolder);
-                                currentList.set(nextHolderIndex, currentHolder);
+                                    LOGGER.warn("Just prevented a crash between %s and %s! Please report the issues to their respective issue trackers.".formatted(currentBiomeLocation == null ? "???" : currentBiomeLocation.getNamespace(), ruleSetterLocation == null ? "???" : ruleSetterLocation.getNamespace()));
+                                    crashesPrevented.incrementAndGet();
+                                    currentList.set(currentHolderIndex, nextHolder);
+                                    currentList.set(nextHolderIndex, currentHolder);
+                                }
                             }
                         }
                     }
                 }
-            }
+                return Unit.INSTANCE;
+            }, FEATURE_RECYCLER_SERVICE);
+            futures[i] = result;
         }
+
+        CompletableFuture.allOf(futures).join();
 
         List<FeatureSorter.StepFeatureData> steps = new ArrayList<>();
 
@@ -151,9 +174,35 @@ public class FeatureRecycler {
 
         LOGGER.info("Finished recycling features. Took %dms".formatted(System.currentTimeMillis() - startTime));
 
-        if (crashesPrevented > 0) {
-            LOGGER.info("Feature Recycler just prevented %d crashes!".formatted(crashesPrevented));
+        if (crashesPrevented.get() > 0) {
+            LOGGER.info("Feature Recycler just prevented %d crashes!".formatted(crashesPrevented.get()));
         }
         return steps;
+    }
+
+    private static final AtomicInteger WORKER_COUNT = new AtomicInteger(1);
+
+    private static ExecutorService makeExecutor() {
+        return new ThreadPoolExecutor(0, GenerationStep.Decoration.values().length,
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<>(), (runnable) -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("Feature-Recycler-Worker-" + WORKER_COUNT.getAndIncrement());
+
+            Thread.UncaughtExceptionHandler uncaughtExceptionHandler = (t, throwable) -> {
+                if (throwable instanceof CompletionException) {
+                    throwable = throwable.getCause();
+                }
+
+                if (throwable instanceof ReportedException) {
+                    Bootstrap.realStdoutPrintln(((ReportedException) throwable).getReport().getFriendlyReport(ReportType.CRASH));
+                    System.exit(-1);
+                }
+
+                LOGGER.error(String.format(Locale.ROOT, "Caught exception in thread %s", thread), throwable);
+            };
+            thread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
+            return thread;
+        });
     }
 }

--- a/common/src/main/java/dev/corgitaco/featurerecycler/FeatureRecycler.java
+++ b/common/src/main/java/dev/corgitaco/featurerecycler/FeatureRecycler.java
@@ -54,17 +54,15 @@ public class FeatureRecycler {
 
         List<Map<T, List<Holder<PlacedFeature>>>> biomeTracker = new ArrayList<>();
 
-        GenerationStep.Decoration[] values = GenerationStep.Decoration.values();
-        for (int i = 0; i < values.length; i++) {
-            biomeTracker.add(new Reference2ObjectLinkedOpenHashMap<>());
-        }
-
-
         for (T biome : biomes) {
-            List<HolderSet<PlacedFeature>> features = toFeatureSetFunction.apply(biome).stream().distinct().toList();
+            List<HolderSet<PlacedFeature>> features = toFeatureSetFunction.apply(biome);
 
             for (int featureStep = 0; featureStep < features.size(); featureStep++) {
                 HolderSet<PlacedFeature> feature = features.get(featureStep);
+
+                if (featureStep >= biomeTracker.size()) {
+                    biomeTracker.add(new Reference2ObjectLinkedOpenHashMap<>());
+                }
                 biomeTracker.get(featureStep).put(biome, new ArrayList<>(feature.stream().toList()));
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 minecraft_version=1.21.1
 
 archives_base_name=Feature-Recycler
-mod_version=2.0.1
+mod_version=2.0.2
 maven_group=dev.corgitaco
 
 fabric_loader_version=0.16.7


### PR DESCRIPTION
This should still fix the issue when two copies of a feature are added to a biome, but without the un-wanted side-effects reported in #6 and #7.  (Although I'm not sure *why* it broke, this change resolves the issues in my testing.)